### PR TITLE
v0.10.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,11 @@ The schema of the type will look like the following instead of describing all th
 ```
 **WARNING:** You **MUST** not rely on the method receivers to return the type and format, because these methods will be called on a new instance created by the generator with the `reflect` package.
 
+You can also override manually the type and format using `OverrideDataType()`. This has the highest precedence.
+```go
+fizz.Generator().OverrideDataType(reflect.TypeOf(&UUIDv4{}), "string", "uuid")
+```
+
 #### Markdown
 
 > Throughout the specification description fields are noted as supporting CommonMark markdown formatting. Where OpenAPI tooling renders rich text it MUST support, at a minimum, markdown syntax as described by CommonMark 0.27. Tooling MAY choose to ignore some CommonMark features to address security concerns.

--- a/openapi/types.go
+++ b/openapi/types.go
@@ -14,6 +14,9 @@ var (
 	tofDataType  = reflect.TypeOf((*DataType)(nil)).Elem()
 )
 
+var _ DataType = (*InternalDataType)(nil)
+var _ DataType = (*OverridedDataType)(nil)
+
 // Typer is the interface implemented
 // by the types that can describe themselves.
 type Typer interface {
@@ -30,7 +33,18 @@ type DataType interface {
 // InternalDataType represents an internal type.
 type InternalDataType int
 
-var _ DataType = (*InternalDataType)(nil)
+// OverridedDataType represents a data type
+// which details override the default generation.
+type OverridedDataType struct {
+	format string
+	typ    string
+}
+
+// Format implements DataType for OverridedDataType.
+func (dt *OverridedDataType) Format() string { return dt.format }
+
+// Type implements DataType for OverridedDataType.
+func (dt *OverridedDataType) Type() string { return dt.typ }
 
 // Type constants.
 const (

--- a/openapi/types_test.go
+++ b/openapi/types_test.go
@@ -158,7 +158,7 @@ func TestCustomDataType(t *testing.T) {
 		assert.Equal(t, "uuid", v.Format())
 		assert.Equal(t, "string", v.Type())
 	} else {
-		t.Error("expected type to implements DataType interface")
+		t.Error("expected type to implements the DataType interface")
 	}
 }
 


### PR DESCRIPTION
* add `OverrideDataType` to manually override the type and
  format of a data type. This has a higher precedence than
  using the DataType interface implementation method.