### PR TITLE
Add InputModel OperationOption

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,12 @@ fizz.Response(statusCode, desc string, model interface{}, headers []*ResponseHea
 // Model can be of any type, and may also be `nil`,
 // in which case the string type will be used as default.
 fizz.Header(name, desc string, model interface{})
+
+// Override the binding model of the operation.
+fizz.InputModel(model interface{})
 ```
+
+**NOTE:** `fizz.InputModel` allows to override the operation input regardless of how the handler implementation really binds the request. It is the developer responsibility to ensure that the parameters binding matches the OpenAPI specification.
 
 **NOTE:** The fist argument of the `fizz.Reponse` method which represents an HTTP status code is of type *string* because the spec accept the value `default`. See the [Responses Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#responsesObject) documentation for more informations.
 

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ fizz.Header(name, desc string, model interface{})
 fizz.InputModel(model interface{})
 ```
 
-**NOTE:** `fizz.InputModel` allows to override the operation input regardless of how the handler implementation really binds the request. It is the developer responsibility to ensure that the parameters binding matches the OpenAPI specification.
-
-**NOTE:** The fist argument of the `fizz.Reponse` method which represents an HTTP status code is of type *string* because the spec accept the value `default`. See the [Responses Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#responsesObject) documentation for more informations.
+**NOTES:**
+* `fizz.InputModel` allows to override the operation input regardless of how the handler implementation really binds the request parameters. It is the developer responsibility to ensure that the binding matches the OpenAPI specification.
+* The fist argument of the `fizz.Reponse` method which represents an HTTP status code is of type *string* because the spec accept the value `default`. See the [Responses Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#responsesObject) documentation for more informations.
 
 To help you declare additional headers, predefined variables for Go primitives types that you can use as the third argument of the `fizz.Header` method are available.
 ```go

--- a/fizz_test.go
+++ b/fizz_test.go
@@ -14,10 +14,10 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/loopfz/gadgeto/tonic"
-	uuid "github.com/satori/go.uuid"
+	"github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/y0ssar1an/q"
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 
 	"github.com/wI2L/fizz/openapi"
 )
@@ -170,6 +170,12 @@ func TestTonicHandler(t *testing.T) {
 	assert.Equal(t, `{"x":"foo","y":1}`, string(body))
 }
 
+type testInputModel struct {
+	PathParam1 string `path:"a"`
+	PathParam2 int    `path:"b"`
+	QueryParam string `query:"q"`
+}
+
 // TestSpecHandler tests that the OpenAPI handler
 // return the spec properly marshaled in JSON.
 func TestSpecHandler(t *testing.T) {
@@ -202,6 +208,13 @@ func TestSpecHandler(t *testing.T) {
 			return nil
 		}, 200),
 	)
+
+	fizz.GET("/test/:a/:b", []OperationOption{
+		ID("GetTest2"),
+		InputModel(&testInputModel{}),
+	}, tonic.Handler(func(c *gin.Context) error {
+		return nil
+	}, 200))
 	infos := &openapi.Info{
 		Title:       "Test Server",
 		Description: `This is a test server.`,

--- a/openapi/operation.go
+++ b/openapi/operation.go
@@ -10,6 +10,7 @@ type OperationInfo struct {
 	Summary           string
 	Description       string
 	Deprecated        bool
+	InputModel        interface{}
 	Responses         []*OperationReponse
 }
 

--- a/testdata/spec.json
+++ b/testdata/spec.json
@@ -45,6 +45,42 @@
                 },
                 "deprecated": true
             }
+        },
+        "/test/{a}/{b}": {
+            "get": {
+                "operationId": "GetTest2",
+                "parameters": [
+                    {
+                        "name": "a",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "b",
+                        "in": "path",
+                        "required": true,
+                        "schema": {
+                            "type": "integer",
+                            "format": "int32"
+                        }
+                    },
+                    {
+                        "name": "q",
+                        "in": "query",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                }
+            }
         }
     },
     "components": {}

--- a/testdata/spec.yaml
+++ b/testdata/spec.yaml
@@ -30,4 +30,26 @@ paths:
               schema:
                 type: string
       deprecated: true
+  /test/{a}/{b}:
+    get:
+      operationId: GetTest2
+      parameters:
+      - name: a
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: b
+        in: path
+        required: true
+        schema:
+          type: integer
+          format: int32
+      - name: q
+        in: query
+        schema:
+          type: string
+      responses:
+        '200':
+          description: OK
 components: {}


### PR DESCRIPTION
InputModel overrides the binding model of an operation, allowing usage of generic handlers.

```go
type testInputModel struct {
	PathParam1 string `path:"a"`
	PathParam2 int    `path:"b"`
	QueryParam string `query:"q"`
}

fizz.GET("/test/:a/:b", []OperationOption{
		ID("GetTest2"),
		InputModel(&testInputModel{}),
	},
	tonic.Handler(func(c *gin.Context) error {
		return nil
	}, 200)
)
```