### PR TITLE
Add SetServers to manually configure spec servers

### DIFF
--- a/fizz_test.go
+++ b/fizz_test.go
@@ -207,6 +207,21 @@ func TestSpecHandler(t *testing.T) {
 		Description: `This is a test server.`,
 		Version:     "1.0.0",
 	}
+	servers := []*openapi.Server{
+		&openapi.Server{
+			URL:         "https://foo.bar/{basePath}",
+			Description: "Such Server, Very Wow",
+			Variables: map[string]*openapi.ServerVariable{
+				"basePath": &openapi.ServerVariable{
+					Default:     "v2",
+					Description: "version of the API",
+					Ennum:       []string{"v1", "v2", "beta"},
+				},
+			},
+		},
+	}
+	fizz.Generator().SetServers(servers)
+
 	fizz.GET("/openapi.json", nil, fizz.OpenAPI(infos, "")) // default is JSON
 	fizz.GET("/openapi.yaml", nil, fizz.OpenAPI(infos, "yaml"))
 

--- a/openapi/generator.go
+++ b/openapi/generator.go
@@ -90,6 +90,12 @@ func (g *Generator) SetInfo(info *Info) {
 	g.api.Info = info
 }
 
+// SetServers sets the server list for the
+// current specification.
+func (g *Generator) SetServers(servers []*Server) {
+	g.api.Servers = servers
+}
+
 // API returns a copy of the internal OpenAPI object.
 func (g *Generator) API() *OpenAPI {
 	cpy := *g.api

--- a/openapi/generator_test.go
+++ b/openapi/generator_test.go
@@ -535,6 +535,29 @@ func TestNewGenWithoutConfig(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+// TestSetServers tests that a custom servers description
+// can be added to the specification and is properly marshaled.
+func TestSetServers(t *testing.T) {
+	g := gen(t)
+
+	servers := []*Server{
+		&Server{URL: "https://dev.api.foo.bar/v1", Description: "Development server"},
+		&Server{URL: "https://prod.api.foo.bar/{basePath}", Description: "Production server", Variables: map[string]*ServerVariable{
+			"basePath": &ServerVariable{
+				Description: "Version of the API",
+				Ennum: []string{
+					"v1", "v2", "beta",
+				},
+				Default: "v2",
+			},
+		}},
+	}
+	g.SetServers(servers)
+
+	assert.NotNil(t, g.API().Servers)
+	assert.Equal(t, servers, g.API().Servers)
+}
+
 func gen(t *testing.T) *Generator {
 	g, err := NewGenerator(genConfig)
 	if err != nil {

--- a/testdata/spec.json
+++ b/testdata/spec.json
@@ -5,6 +5,21 @@
         "description": "This is a test server.",
         "version": "1.0.0"
     },
+    "servers": [{
+        "url": "https://foo.bar/{basePath}",
+        "description": "Such Server, Very Wow",
+        "variables": {
+            "basePath": {
+                "enum": [
+                    "v1",
+                    "v2",
+                    "beta"
+                ],
+                "default": "v2",
+                "description": "version of the API"
+            }
+        }
+    }],
     "paths": {
         "/test/{a}": {
             "get": {

--- a/testdata/spec.yaml
+++ b/testdata/spec.yaml
@@ -3,6 +3,17 @@ info:
   title: Test Server
   description: This is a test server.
   version: 1.0.0
+servers:
+- url: https://foo.bar/{basePath}
+  description: Such Server, Very Wow
+  variables:
+    basePath:
+      enum:
+        - v1
+        - v2
+        - beta
+      default: v2
+      description: version of the API
 paths:
   /test/{a}:
     get:


### PR DESCRIPTION
This will allow configuring custom servers for OpenAPI Specs