### PR TITLE
v0.11.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,17 @@ You can also override manually the type and format using `OverrideDataType()`. T
 fizz.Generator().OverrideDataType(reflect.TypeOf(&UUIDv4{}), "string", "uuid")
 ```
 
+##### Native and imported types support
+
+Fizz supports some native and imported types. A schema with a proper type and format will be generated automatically, removing the need for creating your own custom schema.
+
+* [time.Time](https://golang.org/pkg/time/#Time)
+* [time.Duration](https://golang.org/pkg/time/#Duration)
+* [net.URL](https://golang.org/pkg/net/url/#URL)
+* [net.IP](https://golang.org/pkg/net/#IP)  
+Note that, according to the doc, the inherent version of the address is a semantic property, and thus cannot be determined by Fizz. Therefore, the format returned is simply `ip`. If you want to specify the version, you can use the tags `format:"ipv4"` or `format:"ipv6"`.
+* [uuid.UUID](https://godoc.org/github.com/satori/go.uuid#UUID)
+
 #### Markdown
 
 > Throughout the specification description fields are noted as supporting CommonMark markdown formatting. Where OpenAPI tooling renders rich text it MUST support, at a minimum, markdown syntax as described by CommonMark 0.27. Tooling MAY choose to ignore some CommonMark features to address security concerns.

--- a/openapi/types.go
+++ b/openapi/types.go
@@ -2,6 +2,8 @@ package openapi
 
 import (
 	"fmt"
+	"net"
+	"net/url"
 	"reflect"
 	"strconv"
 	"time"
@@ -10,10 +12,14 @@ import (
 )
 
 var (
+	tofDataType = reflect.TypeOf((*DataType)(nil)).Elem()
+
+	// Native.
 	tofTime      = reflect.TypeOf(time.Time{})
 	tofDuration  = reflect.TypeOf(time.Duration(0))
 	tofByteSlice = reflect.TypeOf([]byte{})
-	tofDataType  = reflect.TypeOf((*DataType)(nil)).Elem()
+	tofNetIP     = reflect.TypeOf(net.IP{})
+	tofNetURL    = reflect.TypeOf(url.URL{})
 
 	// Imported.
 	tofSatoriUUID = reflect.TypeOf(uuid.UUID{})
@@ -64,6 +70,8 @@ const (
 	TypeDate
 	TypeDateTime
 	TypeDuration
+	TypeIP
+	TypeURL
 	TypePassword
 
 	// TypeComplex represents non-primitive types like
@@ -122,6 +130,10 @@ func DataTypeFromType(t reflect.Type) DataType {
 		return TypeDuration
 	case tofByteSlice:
 		return TypeByte
+	case tofNetIP:
+		return TypeIP
+	case tofNetURL:
+		return TypeURL
 	}
 	// Treat imported types.
 	if dt := isImportedType(t); dt != nil {
@@ -162,7 +174,7 @@ func isImportedType(t reflect.Type) DataType {
 
 // stringToType converts val to t's type and return the new value.
 func stringToType(val string, t reflect.Type) (interface{}, error) {
-	// Compare type to know Gokang types.
+	// Compare type to know Golang types.
 	// IT MUST BE EXECUTED BEFORE swithing over
 	// primitives because a time.Duration is itself
 	// an int64.
@@ -204,6 +216,8 @@ var datatypes = [...]string{
 	TypeDate:        "Date",
 	TypeDateTime:    "DateTime",
 	TypeDuration:    "Duration",
+	TypeIP:          "IP Address",
+	TypeURL:         "URL (Uniform Resource Locator)",
 	TypePassword:    "Password",
 	TypeUnsupported: "Unsupported",
 	TypeComplex:     "Complex",
@@ -222,6 +236,8 @@ var types = [...]string{
 	TypeDate:     "string",
 	TypeDateTime: "string",
 	TypeDuration: "string",
+	TypeIP:       "string",
+	TypeURL:      "string",
 	TypePassword: "string",
 	TypeComplex:  "string",
 	TypeUUID:     "string",
@@ -239,6 +255,8 @@ var formats = [...]string{
 	TypeDate:     "date",
 	TypeDateTime: "date-time",
 	TypeDuration: "duration",
+	TypeIP:       "ip",
+	TypeURL:      "url",
 	TypePassword: "password",
 	TypeComplex:  "",
 	TypeUUID:     "uuid",

--- a/openapi/types_test.go
+++ b/openapi/types_test.go
@@ -1,6 +1,8 @@
 package openapi
 
 import (
+	"net"
+	"net/url"
 	"reflect"
 	"testing"
 	"time"
@@ -28,6 +30,8 @@ func TestInternalDataType(t *testing.T) {
 		TypeDate:        {"string", "date"},
 		TypeDateTime:    {"string", "date-time"},
 		TypeDuration:    {"string", "duration"},
+		TypeIP:          {"string", "ip"},
+		TypeURL:         {"string", "url"},
 		TypePassword:    {"string", "password"},
 		TypeComplex:     {"string", ""},
 		TypeBoolean:     {"boolean", ""},
@@ -89,6 +93,8 @@ func TestComplexGoTypeToDataType(t *testing.T) {
 		rt([]byte{}):                 TypeByte,
 		rt(time.Now()):               TypeDateTime,
 		rt(5 * time.Second):          TypeDuration,
+		rt(url.URL{}):                TypeURL,
+		rt(net.IP{}):                 TypeIP,
 		rt(struct{}{}):               TypeComplex,
 		rt([]string{}):               TypeComplex,
 		rt([6]string{}):              TypeComplex,
@@ -124,6 +130,8 @@ func TestInternalDataTypeStringer(t *testing.T) {
 		TypeDate,
 		TypeDateTime,
 		TypeDuration,
+		TypeIP,
+		TypeURL,
 		TypePassword,
 		TypeComplex,
 		TypeBoolean,

--- a/openapi/validation.go
+++ b/openapi/validation.go
@@ -1,6 +1,8 @@
 package openapi
 
-import "reflect"
+import (
+	"reflect"
+)
 
 // setSchemaMax sets the given maximum to the appropriate
 // schema field based on the given type.


### PR DESCRIPTION
* Add schema generation support for `net` types.
* Update documentation about native/imported types that
  are automatically generated.