### PR TITLE
Copy consolidated path for openapi spec

### DIFF
--- a/fizz.go
+++ b/fizz.go
@@ -200,11 +200,11 @@ func (g *RouterGroup) Handle(path, method string, infos []OperationOption, handl
 			it = reflect.TypeOf(oi.InputModel)
 		}
 
-		// Consolidate path.
-		path = joinPaths(g.group.BasePath(), path)
+		// Consolidate path for OpenAPI spec.
+		operationPath := joinPaths(g.group.BasePath(), path)
 
 		// Add operation to the OpenAPI spec.
-		operation, err := g.gen.AddOperation(path, method, g.Name, it, hfunc.OutputType(), oi)
+		operation, err := g.gen.AddOperation(operationPath, method, g.Name, it, hfunc.OutputType(), oi)
 		if err != nil {
 			panic(fmt.Sprintf(
 				"error while generating OpenAPI spec on operation %s %s: %s",


### PR DESCRIPTION
There is currently an issue when using a router group and a tonic handler together. The path is consolidated for the openapi spec operation (but only in case there is a tonic handler), but overrides the path which is later used to declare the route on the underlying gin router.

For example:

```go
r := fizz.New()
g := r.Group("/test", "test", "test group")
g.GET("", tonic.Handler(func (c *gin.Context, in *Input) error {
  ...
}))
```

This example will declare a route in gin as `/test/test` instead of just `/test`.