### PR TITLE
Add example to fizz.Response & add fizz.ResponseWithExamples

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,18 @@ fizz.ID(id string)
 fizz.Deprecated(deprecated bool)
 
 // Add an additional response to the operation.
-// model and header may be `nil`.
-fizz.Response(statusCode, desc string, model interface{}, headers []*ResponseHeader)
+// The example argument will populate a single example in the response schema.
+// For populating multiple examples, use fizz.ResponseWithExamples.
+// Notice that example and examples fields are mutually exclusive.
+// model, header, and example may be `nil`.
+fizz.Response(statusCode, desc string, model interface{}, headers []*ResponseHeader, example interface{})
+
+// ResponseWithExamples is a variant of Response that supports providing multiple examples.
+// Examples argument will populate multiple examples in the response schema.
+// For populating a single example, use fizz.Response.
+// Notice that example and examples fields are mutually exclusive.
+// model, header, and examples may be `nil`.
+fizz.ResponseWithExamples(statusCode, desc string, model interface{}, headers []*ResponseHeader, examples map[string]interface{})
 
 // Add an additional header to the default response.
 // Model can be of any type, and may also be `nil`,

--- a/examples/market/router.go
+++ b/examples/market/router.go
@@ -46,20 +46,25 @@ func routes(grp *fizz.RouterGroup) {
 	// Add a new fruit to the market.
 	grp.POST("", []fizz.OperationOption{
 		fizz.Summary("Add a fruit to the market"),
-		fizz.Response("400", "Bad request", nil, nil),
+		fizz.Response("400", "Bad request", nil, nil,
+			map[string]interface{}{"error": "fruit already exists"},
+		),
 	}, tonic.Handler(CreateFruit, 200))
 
 	// Remove a fruit from the market,
 	// probably because it rotted.
 	grp.DELETE("/:name", []fizz.OperationOption{
 		fizz.Summary("Remove a fruit from the market"),
-		fizz.Response("400", "Fruit not found", nil, nil),
+		fizz.ResponseWithExamples("400", "Bad request", nil, nil, map[string]interface{}{
+			"fruitNotFound": map[string]interface{}{"error": "fruit not found"},
+			"invalidApiKey": map[string]interface{}{"error": "invalid api key"},
+		}),
 	}, tonic.Handler(DeleteFruit, 204))
 
 	// List all available fruits.
 	grp.GET("", []fizz.OperationOption{
 		fizz.Summary("List the fruits of the market"),
-		fizz.Response("400", "Bad request", nil, nil),
+		fizz.Response("400", "Bad request", nil, nil, nil),
 		fizz.Header("X-Market-Listing-Size", "Listing size", fizz.Long),
 	}, tonic.Handler(ListFruits, 200))
 }

--- a/fizz.go
+++ b/fizz.go
@@ -312,7 +312,7 @@ func Deprecated(deprecated bool) func(*openapi.OperationInfo) {
 // Response adds an additional response to the operation.
 func Response(statusCode, desc string, model interface{}, headers []*openapi.ResponseHeader) func(*openapi.OperationInfo) {
 	return func(o *openapi.OperationInfo) {
-		o.Responses = append(o.Responses, &openapi.OperationReponse{
+		o.Responses = append(o.Responses, &openapi.OperationResponse{
 			Code:        statusCode,
 			Description: desc,
 			Model:       model,

--- a/fizz.go
+++ b/fizz.go
@@ -310,13 +310,27 @@ func Deprecated(deprecated bool) func(*openapi.OperationInfo) {
 }
 
 // Response adds an additional response to the operation.
-func Response(statusCode, desc string, model interface{}, headers []*openapi.ResponseHeader) func(*openapi.OperationInfo) {
+func Response(statusCode, desc string, model interface{}, headers []*openapi.ResponseHeader, example interface{}) func(*openapi.OperationInfo) {
 	return func(o *openapi.OperationInfo) {
 		o.Responses = append(o.Responses, &openapi.OperationResponse{
 			Code:        statusCode,
 			Description: desc,
 			Model:       model,
 			Headers:     headers,
+			Example:     example,
+		})
+	}
+}
+
+// ResponseWithExamples is a variant of Response that accept many examples.
+func ResponseWithExamples(statusCode, desc string, model interface{}, headers []*openapi.ResponseHeader, examples map[string]interface{}) func(*openapi.OperationInfo) {
+	return func(o *openapi.OperationInfo) {
+		o.Responses = append(o.Responses, &openapi.OperationResponse{
+			Code:        statusCode,
+			Description: desc,
+			Model:       model,
+			Headers:     headers,
+			Examples:    examples,
 		})
 	}
 }

--- a/fizz_test.go
+++ b/fizz_test.go
@@ -259,6 +259,11 @@ func TestSpecHandler(t *testing.T) {
 					Description: "Rate limit",
 					Model:       Integer,
 				},
+			}, nil),
+			Response("404", "", String, nil, "not-found-example"),
+			ResponseWithExamples("400", "", String, nil, map[string]interface{}{
+				"one": "message1",
+				"two": "message2",
 			}),
 		},
 		tonic.Handler(func(c *gin.Context) error {

--- a/openapi/generator_test.go
+++ b/openapi/generator_test.go
@@ -516,21 +516,75 @@ func TestSetOperationResponseError(t *testing.T) {
 	op := &Operation{
 		Responses: make(Responses),
 	}
-	err := g.setOperationResponse(op, reflect.TypeOf(new(string)), "200", "application/json", "", nil)
+	err := g.setOperationResponse(op, reflect.TypeOf(new(string)), "200", "application/json", "", nil, nil, nil)
 	assert.Nil(t, err)
 
 	// Add another response with same code.
-	err = g.setOperationResponse(op, reflect.TypeOf(new(int)), "200", "application/xml", "", nil)
+	err = g.setOperationResponse(op, reflect.TypeOf(new(int)), "200", "application/xml", "", nil, nil, nil)
 	assert.NotNil(t, err)
 
 	// Add invalid response code that cannot
 	// be converted to an integer.
-	err = g.setOperationResponse(op, reflect.TypeOf(new(bool)), "two-hundred", "", "", nil)
+	err = g.setOperationResponse(op, reflect.TypeOf(new(bool)), "two-hundred", "", "", nil, nil, nil)
 	assert.NotNil(t, err)
 
 	// Add out of range response code.
-	err = g.setOperationResponse(op, reflect.TypeOf(new(bool)), "777", "", "", nil)
+	err = g.setOperationResponse(op, reflect.TypeOf(new(bool)), "777", "", "", nil, nil, nil)
 	assert.NotNil(t, err)
+
+	// Cannot set both example and examples
+	err = g.setOperationResponse(op, reflect.TypeOf(new(bool)), "404", "", "", nil, "notFoundExample", map[string]interface{}{"badRequest": "message"})
+	assert.NotNil(t, err)
+}
+
+// TestSetOperationResponseExample tests that
+// one example is set correctly.
+func TestSetOperationResponseExample(t *testing.T) {
+	g := gen(t)
+	op := &Operation{
+		Responses: make(Responses),
+	}
+
+	error1 := map[string]interface{}{"error": "message1"}
+
+	err := g.setOperationResponse(op, reflect.TypeOf(new(string)), "400", "application/json", "", nil, error1, nil)
+	assert.Nil(t, err)
+
+	// assert example set correctly
+	mt := op.Responses["400"].Response.Content["application/json"].MediaType
+	assert.Equal(t, error1, mt.Example)
+
+	// examples should be empty
+	assert.Nil(t, mt.Examples)
+}
+
+// TestSetOperationResponseExamples tests that
+// multiple examples are set correctly.
+func TestSetOperationResponseExamples(t *testing.T) {
+	g := gen(t)
+	op := &Operation{
+		Responses: make(Responses),
+	}
+
+	error1 := map[string]interface{}{"error": "message1"}
+	error2 := map[string]interface{}{"error": "message2"}
+
+	err := g.setOperationResponse(op, reflect.TypeOf(new(string)), "400", "application/json", "", nil, nil,
+		map[string]interface{}{
+			"one": error1,
+			"two": error2,
+		},
+	)
+	assert.Nil(t, err)
+
+	// assert examples set correctly
+	mt := op.Responses["400"].Response.Content["application/json"].MediaType
+	assert.Equal(t, 2, len(mt.Examples))
+	assert.Equal(t, error1, mt.Examples["one"].Example.Value)
+	assert.Equal(t, error2, mt.Examples["two"].Example.Value)
+
+	// example should be empty
+	assert.Nil(t, mt.Example)
 }
 
 // TestSetOperationParamsError tests the various error

--- a/openapi/generator_test.go
+++ b/openapi/generator_test.go
@@ -364,13 +364,13 @@ func TestAddOperation(t *testing.T) {
 		Summary:     "ABC",
 		Description: "XYZ",
 		Deprecated:  true,
-		Responses: []*OperationReponse{
-			&OperationReponse{
+		Responses: []*OperationResponse{
+			&OperationResponse{
 				Code:        "400",
 				Description: "Bad Request",
 				Model:       CustomError{},
 			},
-			&OperationReponse{
+			&OperationResponse{
 				Code:        "5XX",
 				Description: "Server Errors",
 			},

--- a/openapi/operation.go
+++ b/openapi/operation.go
@@ -31,4 +31,6 @@ type OperationResponse struct {
 	Description string
 	Model       interface{}
 	Headers     []*ResponseHeader
+	Example     interface{}
+	Examples    map[string]interface{}
 }

--- a/openapi/operation.go
+++ b/openapi/operation.go
@@ -11,7 +11,7 @@ type OperationInfo struct {
 	Description       string
 	Deprecated        bool
 	InputModel        interface{}
-	Responses         []*OperationReponse
+	Responses         []*OperationResponse
 }
 
 // ResponseHeader represents a single header that
@@ -22,9 +22,9 @@ type ResponseHeader struct {
 	Model       interface{}
 }
 
-// OperationReponse represents a single response of an
+// OperationResponse represents a single response of an
 // API operation.
-type OperationReponse struct {
+type OperationResponse struct {
 	// The response code can be "default"
 	// according to OAS3 spec.
 	Code        string

--- a/testdata/spec.json
+++ b/testdata/spec.json
@@ -38,6 +38,35 @@
                             }
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                },
+                                "examples": {
+                                    "one": {
+                                        "value": "message1"
+                                    },
+                                    "two": {
+                                        "value": "message2"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "string"
+                                },
+                                "example": "not-found-example"
+                            }
+                        }
+                    },
                     "429": {
                         "description": "Too Many Requests",
                         "headers": {

--- a/testdata/spec.yaml
+++ b/testdata/spec.yaml
@@ -28,6 +28,24 @@ paths:
               description: Unique request ID
               schema:
                 type: string
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: string
+              examples:
+                one:
+                  value: message1
+                two:
+                  value: message2
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: string
+              example: not-found-example
         '429':
           description: Too Many Requests
           headers:


### PR DESCRIPTION
It's me again with proposed changes for handling examples 🙈 

_**NOTICE:** This PR is far from being done, but I just wanted to reach out and check if this is something we want to put in eventually before I spend more time polishing it. Let me know what you think._

### Idea 
With these changes, we could provide one or more examples with the newly proposed `OperationOption`s. The core of the idea is that, even if the response structs for some endpoints (or responses) are the same, we might want to show different examples.

For example in my codebase, we use the `Error` struct (see below) as a generic struct for returning all the server errors. And while the same struct is used on responses with codes `400`, `404`, and `500`, we would like examples to differ; which is not possible with the newly introduced example tags (#43).

Shortly, the PR introduces two more operation information, allowing to set examples:
* `fizz.ResponseWithExample`: extends `fizz.Response` and overwrite _a single_ example,
* `fizz.ResponseWithExamples`: extends `fizz.Response` and overwrite _multiple_ examples.

### Example codebase:
```golang
package main

import (
	"fmt"
	"net/http"

	"github.com/gin-gonic/gin"
	"github.com/loopfz/gadgeto/tonic"
	"github.com/wI2L/fizz"
)

type Error struct {
	Code    string `json:"code" example:"example-value-from-struct"`
	Message string `json:"message" example:"example-value-from-struct"`
}

var (
	ErrorBadRequest1 = Error{"001", "bad request 1"}
	ErrorBadRequest2 = Error{"002", "bad request 2"}
	ErrorBadRequest3 = Error{"003", "bad request 3"}
	ErrorInternal    = Error{"999", "internal server"}
)

func handler(c *gin.Context) error {
	return nil
}

func main() {
	f := fizz.NewFromEngine(gin.New())
	f.GET("/openapi", nil, f.OpenAPI(nil, "json"))

	f.POST(
		"/create",
		[]fizz.OperationOption{
			// case without the example: example value taken from struct if exists
			fizz.Response("404", "Bad request", Error{}, nil),
			// case of passing a single example
			fizz.ResponseWithExample("500", "Internal server error", Error{}, nil, ErrorInternal),
			// case of passing multiple examples
			fizz.ResponseWithExamples("400", "Bad request", Error{}, nil, map[string]interface{}{
				"bad1": ErrorBadRequest1,
				"bad2": ErrorBadRequest2,
				"bad3": ErrorBadRequest3,
			}),
		},
		tonic.Handler(
			handler,
			201,
		),
	)

	fmt.Println("Errors:", f.Errors())

	srv := &http.Server{Addr: ":4242", Handler: f}
	srv.ListenAndServe()
}
```