### PR TITLE
Add Any type for empty interface{} objects

### DIFF
--- a/fizz_test.go
+++ b/fizz_test.go
@@ -229,8 +229,9 @@ type testInputModel struct {
 }
 
 type testInputModel2 struct {
-	C       string `path:"c"`
-	Message string `json:"message" description:"A short message"`
+	C        string      `path:"c"`
+	Message  string      `json:"message" description:"A short message"`
+	AnyValue interface{} `json:"value" description:"A nullable value of arbitrary type"`
 }
 
 // TestSpecHandler tests that the OpenAPI handler

--- a/openapi/generator.go
+++ b/openapi/generator.go
@@ -875,6 +875,14 @@ func (g *Generator) newSchemaFromType(t reflect.Type) *SchemaOrRef {
 			return g.newSchemaFromStruct(t)
 		}
 	}
+	if dt == TypeAny {
+		return &SchemaOrRef{
+			Schema: &Schema{
+				Nullable:    true,
+				Description: "Value of any type, including null",
+			},
+		}
+	}
 	schema := &Schema{
 		Type:     dt.Type(),
 		Format:   dt.Format(),

--- a/openapi/types.go
+++ b/openapi/types.go
@@ -15,11 +15,12 @@ var (
 	tofDataType = reflect.TypeOf((*DataType)(nil)).Elem()
 
 	// Native.
-	tofTime      = reflect.TypeOf(time.Time{})
-	tofDuration  = reflect.TypeOf(time.Duration(0))
-	tofByteSlice = reflect.TypeOf([]byte{})
-	tofNetIP     = reflect.TypeOf(net.IP{})
-	tofNetURL    = reflect.TypeOf(url.URL{})
+	tofTime           = reflect.TypeOf(time.Time{})
+	tofDuration       = reflect.TypeOf(time.Duration(0))
+	tofByteSlice      = reflect.TypeOf([]byte{})
+	tofNetIP          = reflect.TypeOf(net.IP{})
+	tofNetURL         = reflect.TypeOf(url.URL{})
+	tofEmptyInterface = reflect.TypeOf(new(interface{})).Elem()
 
 	// Imported.
 	tofUUID = reflect.TypeOf(uuid.UUID{})
@@ -73,6 +74,7 @@ const (
 	TypeIP
 	TypeURL
 	TypePassword
+	TypeAny
 
 	// TypeComplex represents non-primitive types like
 	// Go struct, for which a schema must be generated.
@@ -134,6 +136,8 @@ func DataTypeFromType(t reflect.Type) DataType {
 		return TypeIP
 	case tofNetURL:
 		return TypeURL
+	case tofEmptyInterface:
+		return TypeAny
 	}
 	// Treat imported types.
 	if dt := isImportedType(t); dt != nil {

--- a/testdata/spec.json
+++ b/testdata/spec.json
@@ -164,6 +164,10 @@
                     "message": {
                         "type": "string",
                         "description": "A short message"
+                    },
+                    "value": {
+                        "description": "A nullable value of arbitrary type",
+                        "nullable": true
                     }
                 }
             }

--- a/testdata/spec.yaml
+++ b/testdata/spec.yaml
@@ -106,3 +106,6 @@ components:
         message:
           type: string
           description: "A short message"
+        value:
+          description: "A nullable value of arbitrary type"
+          nullable: true


### PR DESCRIPTION
Closes https://github.com/wI2L/fizz/issues/51

Added handling for empty `interface{}` so that it's represented like an "any" type in OpenAPI.

From the specs: https://swagger.io/docs/specification/data-models/data-types/#any

> **Any Type**
> A schema without a type matches any data type – numbers, strings, objects, and so on. `{}` is shorthand syntax for an arbitrary-type schema:
> ```yaml
> components:
>   schemas:
>     AnyValue: {}
> ```
> If you want to provide a description:
> ```yaml
> components:
>   schemas:
>     AnyValue:
>       description: Can be any value - string, number, boolean, array or object.
> ```
> The above is equivalent to:
> ```yaml
> components:
>   schemas:
>     AnyValue:
>       anyOf:
>         - type: string
>         - type: number
>         - type: integer
>         - type: boolean
>         - type: array
>           items: {}
>         - type: object
> ```
> If the null value needs to be allowed, add nullable: true:
> ```yaml
> components:
>   schemas:
>     AnyValue:
>       nullable: true
>       description: Can be any value, including `null`.
> ```

