### PR TITLE
Support providing examples for pointer

### DIFF
--- a/openapi/generator.go
+++ b/openapi/generator.go
@@ -1240,6 +1240,8 @@ func parseExampleValue(t reflect.Type, value string) (interface{}, error) {
 		return strconv.ParseUint(value, 10, t.Bits())
 	case reflect.Float32, reflect.Float64:
 		return strconv.ParseFloat(value, t.Bits())
+	case reflect.Ptr:
+		return parseExampleValue(t.Elem(), value)
 	default:
 		return nil, fmt.Errorf("unsuported type: %s", t.String())
 	}

--- a/openapi/generator_test.go
+++ b/openapi/generator_test.go
@@ -232,10 +232,14 @@ func TestNewSchemaFromStructFieldExampleValues(t *testing.T) {
 	g := gen(t)
 
 	type T struct {
-		A string  `example:"value"`
-		B int     `example:"1"`
-		C float64 `example:"0.1"`
-		D bool    `example:"true"`
+		A    string   `example:"value"`
+		APtr *string  `example:"value"`
+		B    int      `example:"1"`
+		BPrt *int     `example:"1"`
+		C    float64  `example:"0.1"`
+		CPtr *float64 `example:"0.1"`
+		D    bool     `example:"true"`
+		DPtr *bool    `example:"true"`
 	}
 	typ := reflect.TypeOf(T{})
 
@@ -244,18 +248,38 @@ func TestNewSchemaFromStructFieldExampleValues(t *testing.T) {
 	assert.NotNil(t, sor)
 	assert.Equal(t, "value", sor.Example)
 
+	// Field APtr contains pointer to string example.
+	sor = g.newSchemaFromStructField(typ.Field(1), false, "APtr", typ)
+	assert.NotNil(t, sor)
+	assert.Equal(t, "value", sor.Example)
+
 	// Field B contains int example.
-	sor = g.newSchemaFromStructField(typ.Field(1), false, "B", typ)
+	sor = g.newSchemaFromStructField(typ.Field(2), false, "B", typ)
+	assert.NotNil(t, sor)
+	assert.Equal(t, int64(1), sor.Example)
+
+	// Field BPtr contains pointer to int example.
+	sor = g.newSchemaFromStructField(typ.Field(3), false, "BPtr", typ)
 	assert.NotNil(t, sor)
 	assert.Equal(t, int64(1), sor.Example)
 
 	// Field C contains float example.
-	sor = g.newSchemaFromStructField(typ.Field(2), false, "C", typ)
+	sor = g.newSchemaFromStructField(typ.Field(4), false, "C", typ)
+	assert.NotNil(t, sor)
+	assert.Equal(t, 0.1, sor.Example)
+
+	// Field CPtr contains pointer to float example.
+	sor = g.newSchemaFromStructField(typ.Field(5), false, "CPtr", typ)
 	assert.NotNil(t, sor)
 	assert.Equal(t, 0.1, sor.Example)
 
 	// Field D contains boolean example.
-	sor = g.newSchemaFromStructField(typ.Field(3), false, "D", typ)
+	sor = g.newSchemaFromStructField(typ.Field(6), false, "D", typ)
+	assert.NotNil(t, sor)
+	assert.Equal(t, true, sor.Example)
+
+	// Field DPtr contains pointer to boolean example.
+	sor = g.newSchemaFromStructField(typ.Field(7), false, "DPtr", typ)
 	assert.NotNil(t, sor)
 	assert.Equal(t, true, sor.Example)
 }
@@ -689,24 +713,58 @@ func TestGenerator_parseExampleValue(t *testing.T) {
 			reflect.TypeOf("value"),
 			"value",
 			"value",
-		}, {
+		},
+		{
+			"mapping pointer to string",
+			reflect.PtrTo(reflect.TypeOf("value")),
+			"value",
+			"value",
+		},
+		{
 			"mapping to int",
 			reflect.TypeOf(1),
 			"1",
 			int64(1),
-		}, {
+		},
+		{
+			"mapping pointer to int",
+			reflect.PtrTo(reflect.TypeOf(1)),
+			"1",
+			int64(1),
+		},
+		{
 			"mapping to uint8",
 			reflect.TypeOf(uint8(1)),
 			"1",
 			uint64(1),
-		}, {
+		},
+		{
+			"mapping pointer to uint8",
+			reflect.PtrTo(reflect.TypeOf(uint8(1))),
+			"1",
+			uint64(1),
+		},
+		{
 			"mapping to number",
 			reflect.TypeOf(1.23),
 			"1.23",
 			1.23,
-		}, {
+		},
+		{
+			"mapping pointer to number",
+			reflect.PtrTo(reflect.TypeOf(1.23)),
+			"1.23",
+			1.23,
+		},
+		{
 			"mapping to boolean",
 			reflect.TypeOf(true),
+			"true",
+			true,
+		},
+		{
+			"mapping pointer to boolean",
+			reflect.PtrTo(reflect.TypeOf(true)),
 			"true",
 			true,
 		},


### PR DESCRIPTION
### The issue
Currently, the `example` tag will not work for fields that are pointers to other values. For example, for this struct:
```go
type Data struct {
	A string `json:"a" example:"valA"`
	B *string `json:"b" example:"valB"`
}
```
the `valA` will be present in the generated spec, while `valB` will not.

### Reasoning
As having pointers to other types is the simplest solution to get `null` values in the JSON responses for missing data (instead of the Go defaults for the corresponding type), I think the `example` tag should also work for pointers.

### Proposed solution
When parsing the `example` tag values, if we get a pointer, try to parse the value that pointer points to.