### PR TITLE
Add OpenAPI security (rebase)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ coverage.txt
 
 # GoLand
 .idea
+
+# VSCode
+.history

--- a/README.md
+++ b/README.md
@@ -98,6 +98,16 @@ fizz.Header(name, desc string, model interface{})
 // Override the binding model of the operation.
 fizz.InputModel(model interface{})
 
+// Overrides the top-level security requirement of an operation.
+// Note that this function can be used more than once to add several requirements.
+fizz.Security(security *openapi.SecurityRequirement)
+
+// Add an empty security requirement to this operation to make other security requirements optional.
+fizz.WithOptionalSecurity()
+
+// Remove any top-level security requirements for this operation.
+fizz.WithoutSecurity()
+
 // Add a Code Sample to the operation.
 fizz.XCodeSample(codeSample *XCodeSample)
 ```
@@ -319,6 +329,7 @@ Fizz supports some native and imported types. A schema with a proper type and fo
 * [`time.Duration`](https://golang.org/pkg/time/#Duration)
 * [`net.URL`](https://golang.org/pkg/net/url/#URL)
 * [`net.IP`](https://golang.org/pkg/net/#IP)
+
 Note that, according to the doc, the inherent version of the address is a semantic property, and thus cannot be determined by Fizz. Therefore, the format returned is simply `ip`. If you want to specify the version, you can use the tags `format:"ipv4"` or `format:"ipv6"`.
 * [`uuid.UUID`](https://godoc.org/github.com/gofrs/uuid#UUID)
 

--- a/fizz.go
+++ b/fizz.go
@@ -360,6 +360,29 @@ func XCodeSample(cs *openapi.XCodeSample) func(*openapi.OperationInfo) {
 	}
 }
 
+// Overrides top-level security requirement for this operation.
+// Note that this function can be used more than once to add several requirements.
+func Security(security *openapi.SecurityRequirement) func(*openapi.OperationInfo) {
+	return func(o *openapi.OperationInfo) {
+		o.Security = append(o.Security, security)
+	}
+}
+
+// Add an empty security requirement to this operation to make other security requirements optional.
+func WithOptionalSecurity() func(*openapi.OperationInfo) {
+	return func(o *openapi.OperationInfo) {
+		var emptyRequirement openapi.SecurityRequirement = make(openapi.SecurityRequirement)
+		o.Security = append(o.Security, &emptyRequirement)
+	}
+}
+
+// Remove any top-level security requirements for this operation.
+func WithoutSecurity() func(*openapi.OperationInfo) {
+	return func(o *openapi.OperationInfo) {
+		o.Security = []*openapi.SecurityRequirement{}
+	}
+}
+
 // OperationFromContext returns the OpenAPI operation from
 // the givent Gin context or an error if none is found.
 func OperationFromContext(c *gin.Context) (*openapi.Operation, error) {

--- a/openapi/generator.go
+++ b/openapi/generator.go
@@ -104,6 +104,12 @@ func (g *Generator) SetServers(servers []*Server) {
 	g.api.Servers = servers
 }
 
+// SetSecurityRequirement sets the security options for the
+// current specification.
+func (g *Generator) SetSecurityRequirement(security *SecurityRequirement) {
+	g.api.Security = security
+}
+
 // API returns a copy of the internal OpenAPI object.
 func (g *Generator) API() *OpenAPI {
 	cpy := *g.api
@@ -251,6 +257,7 @@ func (g *Generator) AddOperation(path, method, tag string, in, out reflect.Type,
 		op.Deprecated = info.Deprecated
 		op.Responses = make(Responses)
 		op.XCodeSamples = info.XCodeSamples
+		op.Security = info.Security
 	}
 	if tag != "" {
 		op.Tags = append(op.Tags, tag)

--- a/openapi/operation.go
+++ b/openapi/operation.go
@@ -12,6 +12,7 @@ type OperationInfo struct {
 	Deprecated        bool
 	InputModel        interface{}
 	Responses         []*OperationResponse
+	Security          []*SecurityRequirement
 	XCodeSamples      []*XCodeSample
 }
 

--- a/testdata/spec.json
+++ b/testdata/spec.json
@@ -5,21 +5,30 @@
         "description": "This is a test server.",
         "version": "1.0.0"
     },
-    "servers": [{
-        "url": "https://foo.bar/{basePath}",
-        "description": "Such Server, Very Wow",
-        "variables": {
-            "basePath": {
-                "enum": [
-                    "v1",
-                    "v2",
-                    "beta"
-                ],
-                "default": "v2",
-                "description": "version of the API"
+    "servers": [
+        {
+            "url": "https://foo.bar/{basePath}",
+            "description": "Such Server, Very Wow",
+            "variables": {
+                "basePath": {
+                    "enum": [
+                        "v1",
+                        "v2",
+                        "beta"
+                    ],
+                    "default": "v2",
+                    "description": "version of the API"
+                }
             }
         }
-    }],
+    ],
+    "security": {
+        "api_key": [],
+        "oauth2": [
+            "write:pets",
+            "read:pets"
+        ]
+    },
     "paths": {
         "/test/{a}": {
             "get": {
@@ -88,13 +97,14 @@
                     }
                 },
                 "deprecated": true,
-                "x-codeSamples":[
+                "x-codeSamples": [
                     {
-                        "lang":"Shell",
-                        "label":"v4.4",
-                        "source":"curl http://0.0.0.0:8080"
+                        "lang": "Shell",
+                        "label": "v4.4",
+                        "source": "curl http://0.0.0.0:8080"
                     }
-                ]
+                ],
+                "security": []
             }
         },
         "/test/{a}/{b}": {
@@ -130,7 +140,16 @@
                     "200": {
                         "description": "OK"
                     }
-                }
+                },
+                "security": [
+                    {},
+                    {
+                        "oauth2": [
+                            "write:pets",
+                            "read:pets"
+                        ]
+                    }
+                ]
             }
         },
         "/test/{c}": {
@@ -175,6 +194,25 @@
                     "value": {
                         "description": "A nullable value of arbitrary type",
                         "nullable": true
+                    }
+                }
+            }
+        },
+        "securitySchemes": {
+            "api_key": {
+                "type": "apiKey",
+                "name": "api_key",
+                "in": "header"
+            },
+            "oauth2": {
+                "type": "oauth2",
+                "flows": {
+                    "implicit": {
+                        "authorizationUrl": "https://example.com/api/oauth/dialog",
+                        "scopes": {
+                            "write:pets": "modify pets in your account",
+                            "read:pets": "read your pets"
+                        }
                     }
                 }
             }

--- a/testdata/spec.yaml
+++ b/testdata/spec.yaml
@@ -14,6 +14,11 @@ servers:
         - beta
       default: v2
       description: version of the API
+security:
+  api_key: []
+  oauth2:
+  - write:pets
+  - read:pets
 paths:
   /test/{a}:
     get:
@@ -63,6 +68,7 @@ paths:
         - lang: Shell
           label: v4.4
           source: curl http://0.0.0.0:8080
+      security: []
   /test/{a}/{b}:
     get:
       operationId: GetTest2
@@ -85,6 +91,11 @@ paths:
       responses:
         '200':
           description: OK
+      security:
+      - {}
+      - oauth2:
+        - write:pets
+        - read:pets
   /test/{c}:
     post:
       operationId: PostTest
@@ -113,3 +124,16 @@ components:
         value:
           description: "A nullable value of arbitrary type"
           nullable: true
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+    oauth2:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://example.com/api/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets


### PR DESCRIPTION
Fixes [Issue #35](https://github.com/wI2L/fizz/issues/35#issue-492088752), continues stale PR #50.

I tried to keep the comments from #50 relevant by resolving conflicts by back-merging and addressing them here. We can squash commits at your discretion.

- adds generator methods
- some edge case test coverage
- marshalling empty `security` field in path section (see [security](https://swagger.io/specification/#oauth-flows-object) parameter - an empty array is used to signal "no security" override)

The last point is the only one that is troublesome since it does not align with the way JSON gets serialised and would benefit from something like [this request](https://github.com/golang/go/issues/22480). The proposed way is backwards compatible but does repeat some code.