### PR TITLE
Add x-internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ fizz.WithoutSecurity()
 // Add a Code Sample to the operation.
 fizz.XCodeSample(codeSample *XCodeSample)
 
-// Mark the operation as internal.
+// Mark the operation as internal. The x-internal flag is interpreted by third-party tools and it only impacts the visual documentation rendering.
 fizz.XInternal()
 ```
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,9 @@ fizz.WithoutSecurity()
 
 // Add a Code Sample to the operation.
 fizz.XCodeSample(codeSample *XCodeSample)
+
+// Mark the operation as internal or external.
+fizz.XInternal(isInternal bool)
 ```
 
 **NOTES:**

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ fizz.WithoutSecurity()
 // Add a Code Sample to the operation.
 fizz.XCodeSample(codeSample *XCodeSample)
 
-// Mark the operation as internal or external.
-fizz.XInternal(isInternal bool)
+// Mark the operation as internal.
+fizz.XInternal()
 ```
 
 **NOTES:**

--- a/fizz.go
+++ b/fizz.go
@@ -383,6 +383,13 @@ func WithoutSecurity() func(*openapi.OperationInfo) {
 	}
 }
 
+// XInternal marks the operation as internal or external.
+func XInternal(isInternal bool) func(*openapi.OperationInfo) {
+	return func(o *openapi.OperationInfo) {
+		o.XInternal = isInternal
+	}
+}
+
 // OperationFromContext returns the OpenAPI operation from
 // the givent Gin context or an error if none is found.
 func OperationFromContext(c *gin.Context) (*openapi.Operation, error) {

--- a/fizz.go
+++ b/fizz.go
@@ -384,9 +384,9 @@ func WithoutSecurity() func(*openapi.OperationInfo) {
 }
 
 // XInternal marks the operation as internal or external.
-func XInternal(isInternal bool) func(*openapi.OperationInfo) {
+func XInternal() func(*openapi.OperationInfo) {
 	return func(o *openapi.OperationInfo) {
-		o.XInternal = isInternal
+		o.XInternal = true
 	}
 }
 

--- a/fizz.go
+++ b/fizz.go
@@ -383,7 +383,7 @@ func WithoutSecurity() func(*openapi.OperationInfo) {
 	}
 }
 
-// XInternal marks the operation as internal or external.
+// XInternal marks the operation as internal.
 func XInternal() func(*openapi.OperationInfo) {
 	return func(o *openapi.OperationInfo) {
 		o.XInternal = true

--- a/fizz_test.go
+++ b/fizz_test.go
@@ -273,7 +273,7 @@ func TestSpecHandler(t *testing.T) {
 			}),
 			// Explicit override for SecurityRequirement (allow-all)
 			WithoutSecurity(),
-			XInternal(true),
+			XInternal(),
 		},
 		tonic.Handler(func(c *gin.Context) error {
 			return nil

--- a/fizz_test.go
+++ b/fizz_test.go
@@ -273,6 +273,7 @@ func TestSpecHandler(t *testing.T) {
 			}),
 			// Explicit override for SecurityRequirement (allow-all)
 			WithoutSecurity(),
+			XInternal(true),
 		},
 		tonic.Handler(func(c *gin.Context) error {
 			return nil

--- a/openapi/generator.go
+++ b/openapi/generator.go
@@ -258,6 +258,7 @@ func (g *Generator) AddOperation(path, method, tag string, in, out reflect.Type,
 		op.Responses = make(Responses)
 		op.XCodeSamples = info.XCodeSamples
 		op.Security = info.Security
+		op.XInternal = info.XInternal
 	}
 	if tag != "" {
 		op.Tags = append(op.Tags, tag)

--- a/openapi/operation.go
+++ b/openapi/operation.go
@@ -14,6 +14,7 @@ type OperationInfo struct {
 	Responses         []*OperationResponse
 	Security          []*SecurityRequirement
 	XCodeSamples      []*XCodeSample
+	XInternal         bool
 }
 
 // ResponseHeader represents a single header that

--- a/openapi/spec.go
+++ b/openapi/spec.go
@@ -198,6 +198,7 @@ type Operation struct {
 	Servers      []*Server              `json:"servers,omitempty" yaml:"servers,omitempty"`
 	Security     []*SecurityRequirement `json:"security" yaml:"security"`
 	XCodeSamples []*XCodeSample         `json:"x-codeSamples,omitempty" yaml:"x-codeSamples,omitempty"`
+	XInternal    bool                   `json:"x-internal,omitempty" yaml:"x-internal,omitempty"`
 }
 
 // A workaround for missing omitnil functionality.
@@ -213,6 +214,7 @@ type operationNilOmitted struct {
 	Deprecated   bool              `json:"deprecated,omitempty" yaml:"deprecated,omitempty"`
 	Servers      []*Server         `json:"servers,omitempty" yaml:"servers,omitempty"`
 	XCodeSamples []*XCodeSample    `json:"x-codeSamples,omitempty" yaml:"x-codeSamples,omitempty"`
+	XInternal    bool              `json:"x-internal,omitempty" yaml:"x-internal,omitempty"`
 }
 
 // MarshalYAML implements yaml.Marshaler for Operation.

--- a/testdata/spec.json
+++ b/testdata/spec.json
@@ -104,7 +104,8 @@
                         "source": "curl http://0.0.0.0:8080"
                     }
                 ],
-                "security": []
+                "security": [],
+                "x-internal": true
             }
         },
         "/test/{a}/{b}": {

--- a/testdata/spec.yaml
+++ b/testdata/spec.yaml
@@ -69,6 +69,7 @@ paths:
           label: v4.4
           source: curl http://0.0.0.0:8080
       security: []
+      x-internal: true
   /test/{a}/{b}:
     get:
       operationId: GetTest2


### PR DESCRIPTION
This PR adds the support for marking the endpoints as `x-internal`, which is a mechanism for hiding endpoints in the rendered docs.

# Background
Some docs rendering tools (e.g. [ReDoc](https://redoc.ly/docs/cli/guides/hide-apis/#1-marking-paths-and-operations-with-x-internal-true) and [Elements](https://github.com/stoplightio/elements/blob/main/docs/getting-started/usage/web-component.md#configuration)) support the functionality of the endpoints to be hidden from the docs, if they are marked as `x-internal`. The changes here add the support for `x-internal`.