### PR TITLE
docs: clarify scope of OpenAPI method

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,7 @@ To serve the generated OpenAPI specification in either `JSON` or `YAML` format, 
 To enrich the specification, you can provide additional informations. Head to the [OpenAPI 3 spec](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#infoObject) for more informations about the API informations that you can specify, or take a look at the type `openapi.Info` in the file [`openapi/spec.go`](openapi/spec.go#L25).
 
 ```go
+f := fizz.New()
 infos := &openapi.Info{
    Title:       "Fruits Market",
    Description: `This is a sample Fruits market server.`,

--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ infos := &openapi.Info{
    Description: `This is a sample Fruits market server.`,
    Version:     "1.0.0",
 }
-f.GET("/openapi.json", nil, fizz.OpenAPI(infos, "json"))
+f.GET("/openapi.json", nil, f.OpenAPI(infos, "json"))
 ```
 **NOTE**: The generator will never panic. However, it is strongly recommended to call `fizz.Errors` to retrieve and handle the errors that may have occured during the generation of the specification before starting your API.
 


### PR DESCRIPTION
I got confused why there is no OpenAPI static method and then realized that it's a struct method  