### PR TITLE
Readd x-tagGroups

### DIFF
--- a/openapi/spec.go
+++ b/openapi/spec.go
@@ -12,6 +12,7 @@ type OpenAPI struct {
 	Components *Components          `json:"components,omitempty" yaml:"components,omitempty"`
 	Tags       []*Tag               `json:"tags,omitempty" yaml:"tags,omitempty"`
 	Security   *SecurityRequirement `json:"security,omitempty" yaml:"security,omitempty"`
+	XTagGroups []*XTagGroup         `json:"x-tagGroups,omitempty" yaml:"x-tagGroups,omitempty"`
 }
 
 // Components holds a set of reusable objects for different


### PR DESCRIPTION
This PR fixes the issue found in the latest [v0.18.0](https://github.com/wI2L/fizz/releases/tag/v0.18.0) release.

`x-tagGroups` which was added in #55 seem to be missing in the latest release. I think the issue happened in the rebasing of the security PR (#59). 