### PR TITLE
fix: omission of x-internal operation field

### DIFF
--- a/openapi/spec.go
+++ b/openapi/spec.go
@@ -247,6 +247,7 @@ func omitOperationNilFields(o *Operation) *operationNilOmitted {
 		Deprecated:   o.Deprecated,
 		Servers:      o.Servers,
 		XCodeSamples: o.XCodeSamples,
+		XInternal:    o.XInternal,
 	}
 }
 


### PR DESCRIPTION
This PR fixes the issue found in the latest [v0.18.0](https://github.com/wI2L/fizz/releases/tag/v0.18.0) release.

`x-internal` is never exposed any more. I think the issue is in the `omitOperationNilFields` where we did not copy the value of `x-internal` over.