### PR TITLE
feat: expose sortParams as a config

### DIFF
--- a/fizz.go
+++ b/fizz.go
@@ -17,6 +17,15 @@ import (
 
 const ctxOpenAPIOperation = "_ctx_openapi_operation"
 
+type FizzConfig struct {
+	// Do the openapi spec generated follow the order of your struct or do we sort the params alphabetically
+	SortParams bool
+}
+
+var Config = FizzConfig{
+	SortParams: true,
+}
+
 // Primitive type helpers.
 var (
 	Integer  int32
@@ -66,6 +75,7 @@ func NewFromEngine(e *gin.Engine) *Fizz {
 			HeaderLocationTag: tonic.HeaderTag,
 			EnumTag:           tonic.EnumTag,
 			DefaultTag:        tonic.DefaultTag,
+			SortParams:        Config.SortParams,
 		},
 	)
 	return &Fizz{

--- a/openapi/generator.go
+++ b/openapi/generator.go
@@ -73,7 +73,7 @@ func NewGenerator(conf *SpecGenConfig) (*Generator, error) {
 		dataTypes:     make(map[reflect.Type]*OverridedDataType),
 		operationsIDS: make(map[string]struct{}),
 		fullNames:     true,
-		sortParams:    true,
+		sortParams:    conf.SortParams,
 		sortTags:      true,
 	}, nil
 }
@@ -90,6 +90,7 @@ type SpecGenConfig struct {
 	HeaderLocationTag string
 	EnumTag           string
 	DefaultTag        string
+	SortParams        bool
 }
 
 // SetInfo uses the given OpenAPI info for the


### PR DESCRIPTION
Hi,

I've needed to expose the sortParam so that I could disable it
The use case is as follow : I have a struct as input for an handler with a lot of fields
I'd like the fields to appear in the same order on the openapi.json as declared on the struct
That allow to display field that are related close to each other, via a swagger ui for example

This PR do not change the default that was to sort the params but it allow user to disable it