### PR TITLE
Use tag to determine if to flatten or not an embedded anonymous field

### DIFF
--- a/openapi/generator.go
+++ b/openapi/generator.go
@@ -1009,8 +1009,10 @@ func (g *Generator) flattenStructSchema(t, parent reflect.Type, schema *Schema) 
 			ft = ft.Elem()
 		}
 		isUnexported := f.PkgPath != ""
+		mediaTag := mediaTags[tonic.MediaType()]
+		_, hasTag := f.Tag.Lookup(mediaTag)
 
-		if f.Anonymous {
+		if f.Anonymous && !hasTag {
 			if isUnexported && ft.Kind() != reflect.Struct {
 				// Ignore embedded fields of unexported non-struct types.
 				continue
@@ -1038,7 +1040,7 @@ func (g *Generator) flattenStructSchema(t, parent reflect.Type, schema *Schema) 
 			// Ignore unexported non-embedded fields.
 			continue
 		}
-		fname := fieldNameFromTag(f, mediaTags[tonic.MediaType()])
+		fname := fieldNameFromTag(f, mediaTag)
 		if fname == "" {
 			// Field has no name, skip it.
 			continue

--- a/openapi/generator_test.go
+++ b/openapi/generator_test.go
@@ -48,6 +48,7 @@ type (
 		*u
 		uu *u // ignored, unexported field
 		q     // ignored, embedded field of non-struct type
+		*Q `json:"data"`
 	}
 	Y struct {
 		H float32   `validate:"required"`
@@ -62,6 +63,9 @@ type (
 		M int `json:"-"`
 	}
 	Z map[string]*Y
+	Q struct {
+		NnNnnN string `json:"nnNnnN"`
+	}
 )
 
 func (*X) TypeName() string { return "XXX" }

--- a/openapi/generator_test.go
+++ b/openapi/generator_test.go
@@ -48,7 +48,8 @@ type (
 		*u
 		uu *u // ignored, unexported field
 		q     // ignored, embedded field of non-struct type
-		*Q `json:"data"`
+		*Q
+		*V `json:"data"`
 	}
 	Y struct {
 		H float32   `validate:"required"`
@@ -65,6 +66,9 @@ type (
 	Z map[string]*Y
 	Q struct {
 		NnNnnN string `json:"nnNnnN"`
+	}
+	V struct {
+		L int
 	}
 )
 

--- a/testdata/schemas/X.json
+++ b/testdata/schemas/X.json
@@ -71,8 +71,11 @@
             "type": "integer",
             "format": "int32"
         },
+        "nnNnnN":{
+            "type":"string"
+        },
         "data": {
-            "$ref": "#/components/schemas/Q"
+            "$ref": "#/components/schemas/V"
         }
     },
     "required": [

--- a/testdata/schemas/X.json
+++ b/testdata/schemas/X.json
@@ -70,6 +70,9 @@
         "S": {
             "type": "integer",
             "format": "int32"
+        },
+        "data": {
+            "$ref": "#/components/schemas/Q"
         }
     },
     "required": [


### PR DESCRIPTION
If we would take for example a kube object [Pod](https://github.com/kubernetes/api/blob/master/core/v1/types.go#L3939) it has `ObjectMeta` as an embedded field but if we render it via `json.Marshal` we would get a nice `metadata` field in our json.
However in our OpenAPI definition this field would be missing.