### PR TITLE
fix(spec): marshal OAuthFlow's scopes as an empty map if nil

### DIFF
--- a/openapi/spec.go
+++ b/openapi/spec.go
@@ -407,6 +407,16 @@ type OAuthFlow struct {
 	Scopes           map[string]string `json:"scopes,omitempty" yaml:"scopes,omitempty"`
 }
 
+// MarshalYAML implements yaml.Marshaler for OAuthFlow.
+func (f OAuthFlow) MarshalYAML() ([]byte, error) {
+	type flow OAuthFlow
+	if f.Scopes == nil {
+		// The field is REQUIRED and MAY be empty according to the spec.
+		f.Scopes = map[string]string{}
+	}
+	return json.Marshal(flow(f))
+}
+
 // SecurityRequirement represents the security object in the API specification.
 type SecurityRequirement map[string][]string
 


### PR DESCRIPTION
The field is required by the spec, and may be empty.

closes #86