### PR TITLE
Nullable enum fields

### DIFF
--- a/openapi/generator.go
+++ b/openapi/generator.go
@@ -842,12 +842,8 @@ func (g *Generator) enumFromStructField(sf reflect.StructField, fname string, pa
 		values := strings.Split(etag, ",")
 		sftype := sf.Type
 
-		// Use pointed element type if it's a pointer
-		if sftype.Kind() == reflect.Ptr {
-			sftype = sftype.Elem()
-		}
-		// Use underlying element type if it's an array or a slice.
-		if sftype.Kind() == reflect.Slice || sftype.Kind() == reflect.Array {
+		// Use underlying element type if it's an array/slice/pointer
+		for sftype.Kind() == reflect.Ptr || sftype.Kind() == reflect.Slice || sftype.Kind() == reflect.Array {
 			sftype = sftype.Elem()
 		}
 		for _, val := range values {

--- a/openapi/generator.go
+++ b/openapi/generator.go
@@ -842,7 +842,11 @@ func (g *Generator) enumFromStructField(sf reflect.StructField, fname string, pa
 		values := strings.Split(etag, ",")
 		sftype := sf.Type
 
-		// Use underlying element type if its an array or a slice.
+		// Use pointed element type if it's a pointer
+		if sftype.Kind() == reflect.Ptr {
+			sftype = sftype.Elem()
+		}
+		// Use underlying element type if it's an array or a slice.
 		if sftype.Kind() == reflect.Slice || sftype.Kind() == reflect.Array {
 			sftype = sftype.Elem()
 		}

--- a/openapi/generator_test.go
+++ b/openapi/generator_test.go
@@ -386,6 +386,39 @@ func TestNewSchemaFromStructFieldFormat(t *testing.T) {
 	assert.Equal(t, sor.Schema.Format, "email")
 }
 
+func TestNewSchemaFromEnumField(t *testing.T) {
+	g := gen(t)
+
+	type T struct {
+		A string  `enum:"a,b,c"`
+		B int     `enum:"1,2,3"`
+		C *string `enum:"d,e,f"`
+		D *int    `enum:"4,5,6"`
+	}
+
+	typ := reflect.TypeOf(T{})
+
+	sor := g.newSchemaFromStructField(typ.Field(0), true, "A", typ)
+	assert.NotNil(t, sor)
+	assert.Equal(t, sor.Nullable, false)
+	assert.Equal(t, []interface{}{"a", "b", "c"}, sor.Enum)
+
+	sor = g.newSchemaFromStructField(typ.Field(1), true, "B", typ)
+	assert.NotNil(t, sor)
+	assert.Equal(t, sor.Nullable, false)
+	assert.Equal(t, []interface{}{int64(1), int64(2), int64(3)}, sor.Enum)
+
+	sor = g.newSchemaFromStructField(typ.Field(2), false, "C", typ)
+	assert.NotNil(t, sor)
+	assert.Equal(t, sor.Nullable, true)
+	assert.Equal(t, []interface{}{"d", "e", "f"}, sor.Enum)
+
+	sor = g.newSchemaFromStructField(typ.Field(3), false, "D", typ)
+	assert.NotNil(t, sor)
+	assert.Equal(t, sor.Nullable, true)
+	assert.Equal(t, []interface{}{int64(4), int64(5), int64(6)}, sor.Enum)
+}
+
 func diffJSON(a, b []byte) (bool, error) {
 	var j, j2 interface{}
 	if err := json.Unmarshal(a, &j); err != nil {


### PR DESCRIPTION
Defining an optional (pointer) enum field results in an error:

```
type Param struct {
	EnumParam *string `query:"enumParam" enum:"a,b" example:"a" default:"a" description:"Enum parameter"`
}
```

`enum value a cannot be converted to field type: unknown type *string: field=enumParam, type=`

Since nullable enum fields are viable, this PR adds support for them