### PR TITLE
feat: set a description to the schema request body

### DIFF
--- a/openapi/generator.go
+++ b/openapi/generator.go
@@ -458,6 +458,14 @@ func (g *Generator) setOperationParams(op *Operation, t, parent reflect.Type, al
 		}
 		sch := op.RequestBody.Content[mt].Schema
 		if sch != nil {
+			// Get description
+			if t.Implements(tofDescriptor) {
+				i, ok := reflect.New(t).Interface().(Descriptor)
+				if ok {
+					sch.Schema.Description = i.Description()
+				}
+			}
+
 			name := strings.Title(op.ID) + "Input"
 			g.api.Components.Schemas[name] = sch
 			op.RequestBody.Content[mt].Schema = &SchemaOrRef{Reference: &Reference{

--- a/openapi/types.go
+++ b/openapi/types.go
@@ -12,8 +12,9 @@ import (
 )
 
 var (
-	tofDataType = reflect.TypeOf((*DataType)(nil)).Elem()
-	tofNullable = reflect.TypeOf((*Nullable)(nil)).Elem()
+	tofDataType   = reflect.TypeOf((*DataType)(nil)).Elem()
+	tofNullable   = reflect.TypeOf((*Nullable)(nil)).Elem()
+	tofDescriptor = reflect.TypeOf((*Descriptor)(nil)).Elem()
 
 	// Native.
 	tofTime           = reflect.TypeOf(time.Time{})
@@ -47,6 +48,12 @@ type DataType interface {
 // that can parse example values.
 type Exampler interface {
 	ParseExample(v string) (interface{}, error)
+}
+
+// Descriptor is the interface implemented by the RequestBody input schema
+// that provides a description for this schema kind
+type Descriptor interface {
+	Description() string
 }
 
 // Nullable is the interface implemented by the types


### PR DESCRIPTION
Allow to set a description to a schema used as request body

Example:
Input struct:
```
type RouteInput struct {
    _ struct{} `json:"-" description:"Description of the input schema"`
    FieldA string `json:"field_a" description:"field_a description"`
    ...
}
```

Generated schema:
```
{
	"RouteInput": {
		"type": "object",
		"properties": {
			"field_a": {
				"type": "string",
				"description": "field_a description"
			},
			...
		},
		"description": "Description of the input schema",
	}
}
```