### PR TITLE
fix: set nullable when it's a pointer of Struct

### DIFF
--- a/openapi/generator.go
+++ b/openapi/generator.go
@@ -895,7 +895,17 @@ func (g *Generator) newSchemaFromType(t reflect.Type) *SchemaOrRef {
 		case reflect.Slice, reflect.Array, reflect.Map:
 			return g.buildSchemaRecursive(t)
 		case reflect.Struct:
-			return g.newSchemaFromStruct(t)
+			sor := g.newSchemaFromStruct(t)
+			var schema *Schema
+			if sor != nil && sor.Schema != nil {
+				schema = sor.Schema
+			} else if sor != nil {
+				schema = g.resolveSchema(sor)
+			}
+			if schema != nil {
+				schema.Nullable = nullable
+			}
+			return sor
 		}
 	}
 	if dt == TypeAny {

--- a/openapi/generator_test.go
+++ b/openapi/generator_test.go
@@ -228,6 +228,7 @@ func TestSchemaFromComplex(t *testing.T) {
 	sor = g.API().Components.Schemas["Y"]
 	schema = g.resolveSchema(sor)
 	assert.NotNil(t, schema)
+	assert.True(t, schema.Nullable)
 
 	actual, err = json.Marshal(schema)
 	if err != nil {


### PR DESCRIPTION
Not sure about it. Normally the schema can be used only one time with Tonic(?)