### PR TITLE
feat: Support add additional tags to operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ fizz.XCodeSample(codeSample *XCodeSample)
 
 // Mark the operation as internal. The x-internal flag is interpreted by third-party tools and it only impacts the visual documentation rendering.
 fizz.XInternal()
+
+// Add additional tags to the operation.
+fizz.WithTags(tags ...string)
 ```
 
 **NOTES:**

--- a/fizz.go
+++ b/fizz.go
@@ -401,6 +401,12 @@ func XInternal() func(*openapi.OperationInfo) {
 	}
 }
 
+func WithTags(tags ...string) func(*openapi.OperationInfo) {
+	return func(o *openapi.OperationInfo) {
+		o.Tags = tags
+	}
+}
+
 // OperationFromContext returns the OpenAPI operation from
 // the given Gin context or an error if none is found.
 func OperationFromContext(ctx context.Context) (*openapi.Operation, error) {

--- a/fizz_test.go
+++ b/fizz_test.go
@@ -308,6 +308,7 @@ func TestSpecHandler(t *testing.T) {
 			// Explicit override for SecurityRequirement (allow-all)
 			WithoutSecurity(),
 			XInternal(),
+			WithTags("TestTag1", "TestTag2"),
 		},
 		tonic.Handler(func(c *gin.Context, in *testInputModel1) (*T, error) {
 			return &T{}, nil

--- a/openapi/generator.go
+++ b/openapi/generator.go
@@ -265,6 +265,7 @@ func (g *Generator) AddOperation(path, method, tag string, in, out reflect.Type,
 		op.XCodeSamples = info.XCodeSamples
 		op.Security = info.Security
 		op.XInternal = info.XInternal
+		op.Tags = info.Tags
 	}
 	if tag != "" {
 		op.Tags = append(op.Tags, tag)

--- a/openapi/operation.go
+++ b/openapi/operation.go
@@ -15,6 +15,7 @@ type OperationInfo struct {
 	Security          []*SecurityRequirement
 	XCodeSamples      []*XCodeSample
 	XInternal         bool
+	Tags              []string
 }
 
 // ResponseHeader represents a single header that

--- a/testdata/spec.json
+++ b/testdata/spec.json
@@ -126,7 +126,8 @@
                     }
                 ],
                 "security": [],
-                "x-internal": true
+                "x-internal": true,
+                "tags": ["TestTag1", "TestTag2"]
             }
         },
         "/test/{a}/{b}": {

--- a/testdata/spec.yaml
+++ b/testdata/spec.yaml
@@ -80,6 +80,9 @@ paths:
           source: curl http://0.0.0.0:8080
       security: []
       x-internal: true
+      tags:
+        - TestTag1
+        - TestTag2
   /test/{a}/{b}:
     get:
       operationId: GetTest2


### PR DESCRIPTION
Originally, this module does not support setting multiple tags for an operation. This PR introduces a new OperationOption that can be used to add arbitrary tags to an operation.