### PR TITLE
feat(openapi/explode): explicitly set false in specs

### DIFF
--- a/fizz_test.go
+++ b/fizz_test.go
@@ -253,9 +253,10 @@ func TestTonicHandler(t *testing.T) {
 }
 
 type testInputModel struct {
-	PathParam1 string `path:"a"`
-	PathParam2 int    `path:"b"`
-	QueryParam string `query:"q"`
+	PathParam1        string   `path:"a"`
+	PathParam2        int      `path:"b"`
+	QueryParam        string   `query:"q"`
+	ExplodeQueryParam []string `query:"eq" explode:"false"`
 }
 
 type testInputModel1 struct {

--- a/openapi/generator.go
+++ b/openapi/generator.go
@@ -692,11 +692,12 @@ func (g *Generator) newParameterFromField(idx int, t reflect.Type) (*Parameter, 
 	// Style.
 	if location == g.config.QueryLocationTag {
 		if field.Type.Kind() == reflect.Slice || field.Type.Kind() == reflect.Array {
-			p.Explode = true // default
-			p.Style = "form" // default in spec, but make it obvious
+			p.Explode = new(bool)
+			*p.Explode = true // default
+			p.Style = "form"  // default in spec, but make it obvious
 			if t := field.Tag.Get(tonic.ExplodeTag); t != "" {
 				if explode, err := strconv.ParseBool(t); err == nil && !explode { // ignore invalid values
-					p.Explode = explode
+					*p.Explode = explode
 				}
 			}
 		}
@@ -1255,7 +1256,7 @@ func fieldNameFromTag(sf reflect.StructField, tagName string) string {
 	return name
 }
 
-/// parseExampleValue is used to transform the string representation of the example value to the correct type.
+// / parseExampleValue is used to transform the string representation of the example value to the correct type.
 func parseExampleValue(t reflect.Type, value string) (interface{}, error) {
 	// If the type implements Exampler use the ParseExample method to create the example
 	i, ok := reflect.New(t).Interface().(Exampler)

--- a/openapi/spec.go
+++ b/openapi/spec.go
@@ -106,7 +106,7 @@ type Parameter struct {
 	AllowEmptyValue bool         `json:"allowEmptyValue,omitempty" yaml:"allowEmptyValue,omitempty"`
 	Schema          *SchemaOrRef `json:"schema,omitempty" yaml:"schema,omitempty"`
 	Style           string       `json:"style,omitempty" yaml:"style,omitempty"`
-	Explode         bool         `json:"explode,omitempty" yaml:"explode,omitempty"`
+	Explode         *bool        `json:"explode,omitempty" yaml:"explode,omitempty"`
 }
 
 // ParameterOrRef represents a Parameter that can be inlined

--- a/testdata/spec.json
+++ b/testdata/spec.json
@@ -151,6 +151,18 @@
                         }
                     },
                     {
+                        "name": "eq",
+                        "in": "query",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        },
+                        "style": "form",
+                        "explode": false
+                    },
+                    {
                         "name": "q",
                         "in": "query",
                         "schema": {

--- a/testdata/spec.yaml
+++ b/testdata/spec.yaml
@@ -95,6 +95,14 @@ paths:
         schema:
           type: integer
           format: int32
+      - name: eq
+        in: query
+        schema:
+          type: array
+          items:
+            type: string
+        style: form
+        explode: false
       - name: q
         in: query
         schema:


### PR DESCRIPTION
## Why 
Using `omitempty` with bool type ends up having the configuration not being set in openapi spec file.

As default value for the `explode` configuration is `true` (see [this page](https://swagger.io/docs/specification/serialization/)), when we want to set it to false, it is not defined in the spec file.

Example reproducer based on this repository master branch:

```golang
package main

import (
        "io/ioutil"
        "log"
        "net/http/httptest"
        "time"

        "github.com/gin-gonic/gin"
        "github.com/loopfz/gadgeto/tonic"
        "github.com/wI2L/fizz"
        "github.com/wI2L/fizz/openapi"
)

type inputModel struct {
        MyQueryParam []string `query:"myQueryParam" explode:"false"`
}

func main() {
        f := fizz.New()

        f.GET("/test", []fizz.OperationOption{
                fizz.InputModel(&inputModel{}),
        }, tonic.Handler(func(c *gin.Context) error {
                return nil
        }, 200))

        infos := &openapi.Info{
                Title:       "Test Server",
                Description: `This is a test server.`,
                Version:     "1.0.0",
        }
        f.GET("/openapi.json", nil, f.OpenAPI(infos, "")) // default is JSON
        srv := httptest.NewServer(f)
        defer srv.Close()

        c := srv.Client()
        c.Timeout = 1 * time.Second

        respJSON, _ := c.Get(srv.URL + "/openapi.json")
        defer respJSON.Body.Close()

        specJSON, _ := ioutil.ReadAll(respJSON.Body)
        log.Println(string(specJSON))
}
```

json spec output:

```json
{
  "openapi": "3.0.1",
  "info": {
    "title": "Test Server",
    "description": "This is a test server.",
    "version": "1.0.0"
  },
  "paths": {
    "/test": {
      "get": {
        "operationId": "func1",
        "parameters": [
          {
            "name": "myQueryParam",
            "in": "query",
            "schema": {
              "type": "array",
              "items": {
                "type": "string"
              }
            },
            "style": "form"
          }
        ],
        "responses": {
          "200": {
            "description": "OK"
          }
        }
      }
    }
  },
  "components": {}
}
```

As you can see, explode is missing in the `myQueryParam` parameter configuration, making it impossible to override it's default value which is `true`.

When I set `explode:"true"` in `inputModel` struct, spec file looks like this:

```json
{
  "openapi": "3.0.1",
  "info": {
    "title": "Test Server",
    "description": "This is a test server.",
    "version": "1.0.0"
  },
  "paths": {
    "/test": {
      "get": {
        "operationId": "func1",
        "parameters": [
          {
            "name": "myQueryParam",
            "in": "query",
            "schema": {
              "type": "array",
              "items": {
                "type": "string"
              }
            },
            "style": "form",
            "explode": true
          }
        ],
        "responses": {
          "200": {
            "description": "OK"
          }
        }
      }
    }
  },
  "components": {}
}
```


With `true`, swagger will generate the following query parameter string: `?myQueryParam=a&myQueryParam=b`, while when set it `false`, it generates `?myQueryParam=a,b`. Where `a` and `b` are fake values for `myQueryParam`.