### PR TITLE
fix(openapi/spec): convert allOf, oneOf and anyOf to slices

### DIFF
--- a/openapi/spec.go
+++ b/openapi/spec.go
@@ -153,9 +153,9 @@ type Schema struct {
 	// definition but their definitions were adjusted to the
 	// OpenAPI Specification.
 	Type                 string                  `json:"type,omitempty" yaml:"type,omitempty"`
-	AllOf                *SchemaOrRef            `json:"allOf,omitempty" yaml:"allOf,omitempty"`
-	OneOf                *SchemaOrRef            `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
-	AnyOf                *SchemaOrRef            `json:"anyOf,omitempty" yaml:"anyOf,omitempty"`
+	AllOf                *[]SchemaOrRef          `json:"allOf,omitempty" yaml:"allOf,omitempty"`
+	OneOf                *[]SchemaOrRef          `json:"oneOf,omitempty" yaml:"oneOf,omitempty"`
+	AnyOf                *[]SchemaOrRef          `json:"anyOf,omitempty" yaml:"anyOf,omitempty"`
 	Items                *SchemaOrRef            `json:"items,omitempty" yaml:"items,omitempty"`
 	Properties           map[string]*SchemaOrRef `json:"properties,omitempty" yaml:"properties,omitempty"`
 	AdditionalProperties *SchemaOrRef            `json:"additionalProperties,omitempty" yaml:"additionalProperties,omitempty"`


### PR DESCRIPTION
As per the spec https://json-schema.org/draft/2020-12/json-schema-core#section-10.2.1.1, allOf, oneOf and anyOf must be non-empty arrays.

Closes #109.