### PR TITLE
feat: Add the possibility to set examples to the default handler behvior

### DIFF
--- a/fizz.go
+++ b/fizz.go
@@ -346,6 +346,13 @@ func ResponseWithExamples(statusCode, desc string, model interface{}, headers []
 	}
 }
 
+// DefaultResponseExamples adds additional examples to the default response.
+func DefaultResponseExamples(examples map[string]interface{}) func(*openapi.OperationInfo) {
+	return func(o *openapi.OperationInfo) {
+		o.DefaultResponseExamples = examples
+	}
+}
+
 // Header adds a header to the operation.
 func Header(name, desc string, model interface{}) func(*openapi.OperationInfo) {
 	return func(o *openapi.OperationInfo) {

--- a/openapi/generator.go
+++ b/openapi/generator.go
@@ -289,7 +289,7 @@ func (g *Generator) AddOperation(path, method, tag string, in, out reflect.Type,
 	// Generate the default response from the tonic
 	// handler return type. If the handler has no output
 	// type, the response won't have a schema.
-	if err := g.setOperationResponse(op, out, strconv.Itoa(info.StatusCode), tonic.MediaType(), info.StatusDescription, info.Headers, nil, nil); err != nil {
+	if err := g.setOperationResponse(op, out, strconv.Itoa(info.StatusCode), tonic.MediaType(), info.StatusDescription, info.Headers, nil, info.DefaultResponseExamples); err != nil {
 		return nil, err
 	}
 	// Generate additional responses from the operation
@@ -1255,7 +1255,7 @@ func fieldNameFromTag(sf reflect.StructField, tagName string) string {
 	return name
 }
 
-/// parseExampleValue is used to transform the string representation of the example value to the correct type.
+// parseExampleValue is used to transform the string representation of the example value to the correct type.
 func parseExampleValue(t reflect.Type, value string) (interface{}, error) {
 	// If the type implements Exampler use the ParseExample method to create the example
 	i, ok := reflect.New(t).Interface().(Exampler)

--- a/openapi/operation.go
+++ b/openapi/operation.go
@@ -3,18 +3,19 @@ package openapi
 // OperationInfo represents the informations of an operation
 // that will be used when generating the OpenAPI specification.
 type OperationInfo struct {
-	ID                string
-	StatusCode        int
-	StatusDescription string
-	Headers           []*ResponseHeader
-	Summary           string
-	Description       string
-	Deprecated        bool
-	InputModel        interface{}
-	Responses         []*OperationResponse
-	Security          []*SecurityRequirement
-	XCodeSamples      []*XCodeSample
-	XInternal         bool
+	ID                      string
+	StatusCode              int
+	StatusDescription       string
+	Headers                 []*ResponseHeader
+	Summary                 string
+	Description             string
+	Deprecated              bool
+	InputModel              interface{}
+	Responses               []*OperationResponse
+	Security                []*SecurityRequirement
+	XCodeSamples            []*XCodeSample
+	XInternal               bool
+	DefaultResponseExamples map[string]interface{}
 }
 
 // ResponseHeader represents a single header that


### PR DESCRIPTION
When trying to add examples for the default tonic status with the function fizz.Response like this:

```
routerGroup.POST(
            "", []fizz.OperationOption{
                fizz.Summary("My Summary"),
                fizz.ResponseWithExamples(
                    fmt.Sprintf("%d", http.StatusAccepted),
                    "toto", nil, nil, map[string]string{
                        "example ": "example",
                    }),
            },
            tonic.Handler(<the_handler>, http.StatusAccepted),
        )
```

we get the following error:

`panic: error while generating OpenAPI spec on operation XXXX : response with code XXX already exists [recovered,repanicked]`

This request add the possibility to set multiples examples for the default handler behavior.